### PR TITLE
Fix utils heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cd "$HOME/dotfiles" && git clone https://github.com/yish8213/dotfiles.git . && .
 
 That's it!
 
-### Utlils
+### Utils
 
 ```bash
 unlink-all.sh     # remove all the symbolic links in the target directory


### PR DESCRIPTION
## Summary
- fix the utils heading typo in README

## Testing
- `grep -n "Utils" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_684d97e445a8832fa8a75550fba8c107