### PR TITLE
Fix find warning in unlink script

### DIFF
--- a/unlink-all.sh
+++ b/unlink-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-linklist=$(find -L "$HOME" -type l -maxdepth 1)
+linklist=$(find -L "$HOME" -maxdepth 1 -type l)
 for link in $linklist
 do
   unlink "$link"


### PR DESCRIPTION
## Summary
- clean up `unlink-all.sh` by moving `-maxdepth` before `-type` to avoid warnings

## Testing
- `shellcheck unlink-all.sh`
- `bash unlink-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d78ba31d8832f8350aa6166f93c4a